### PR TITLE
Find paniclog_append_noflush by resolving adrs

### DIFF
--- a/pongo_kextload/source/common.c
+++ b/pongo_kextload/source/common.c
@@ -53,6 +53,18 @@ void *RESOLVE_ADRP_ADD(uint32_t *insn) {
 	return ptr_for_va(target);
 }
 
+void *RESOLVE_ADR(uint32_t *insn) {
+	uint32_t adr = *insn;
+	// Disallow sp
+	if (bits(adr, 0, 4, 0, 0) == 0x1f) {
+		return NULL;
+	}
+	uint64_t pc = va_for_ptr(insn);
+	uint64_t imm0 = bits(adr, 1, 23, 5, 2) | bits(adr, 0, 30, 29, 0);
+	uint64_t target = pc + imm0;
+	return ptr_for_va(target);
+}
+
 /* no sign support */
 int atoi(const char *s){
     int res = 0;

--- a/pongo_kextload/source/common.h
+++ b/pongo_kextload/source/common.h
@@ -22,6 +22,7 @@ void ktrw_fatal_error(void);
 uintmax_t bits(uintmax_t, unsigned, unsigned, unsigned, unsigned);
 bool MATCH(uint32_t, uint32_t, uint32_t);
 void *RESOLVE_ADRP_ADD(uint32_t *);
+void *RESOLVE_ADR(uint32_t *);
 int atoi(const char *);
 
 

--- a/pongo_kextload/source/pf/14/pf.c
+++ b/pongo_kextload/source/pf/14/pf.c
@@ -336,6 +336,7 @@ bool paniclog_append_noflush_finder_14(xnu_pf_patch_t *patch,
     uint32_t *opcode_stream = cacheable_stream;
 
 	void *target = RESOLVE_ADRP_ADD(opcode_stream + 2);
+    target = target ? target : RESOLVE_ADR(opcode_stream + 2);
 
     if(!target)
         return false;


### PR DESCRIPTION
On 14.7 the adrp/add pair is just an adr, so this detects that.